### PR TITLE
Fix linker errors and compilation issues on Linux/Ubuntu 22.04 with gcc 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,19 @@ ModelManifest.xml
 /tr2.bat
 /tr.bat
 /test
+
+# Qt build artifacts
+*.o
+*.a
+moc_*.cpp
+moc_*.h
+ui_*.h
+qrc_*.cpp
+*.pro.user
+*.pro.user.*
+.qmake.stash
+Makefile*
+zkanji
+zkanji.ini
+data/
+import_data/

--- a/checked_cast.h
+++ b/checked_cast.h
@@ -18,6 +18,7 @@
 #endif
 
 #include <cassert>
+#include <cstdint>
 
 /*
 // Converts T value to RESULT_TYPE, which must be a signed number. RESULT_TYPE is by default

--- a/groups.cpp
+++ b/groups.cpp
@@ -2786,3 +2786,8 @@ void Groups::processRemovedWord(int windex)
 
 //-------------------------------------------------------------
 
+template GroupCategory<KanjiGroup>::self_type* GroupCategory<KanjiGroup>::categories(int index);
+template const GroupCategory<KanjiGroup>::self_type* GroupCategory<KanjiGroup>::categories(int index) const;
+template GroupCategory<WordGroup>::self_type* GroupCategory<WordGroup>::categories(int index);
+template const GroupCategory<WordGroup>::self_type* GroupCategory<WordGroup>::categories(int index) const;
+

--- a/zcolorcombobox.h
+++ b/zcolorcombobox.h
@@ -125,8 +125,8 @@ private:
     int oldindex;
 
     using QComboBox::activated;
-    using QComboBox::activated;
-    using QComboBox::currentIndexChanged;
+    // using QComboBox::activated;
+    // using QComboBox::currentIndexChanged;
     using QComboBox::currentIndexChanged;
     using QComboBox::currentTextChanged;
 


### PR DESCRIPTION
This PR fixes compilation and linker errors that occur when building zkanji on Ubuntu 22.04 with gcc 13.

## Issues Fixed

### 1. Linker Errors for GroupCategory Template
**Problem:** The build failed with undefined reference errors:
- `undefined reference to 'GroupCategory<KanjiGroup>::categories(int)'`
- `undefined reference to 'GroupCategory<WordGroup>::categories(int)'`

**Solution:** Added explicit template instantiations for the `categories()` method in `groups.cpp` to ensure the linker can find the required symbols.

### 2. Missing Header Include
**Problem:** Compilation error due to missing `#include <cstdint>` in `checked_cast.h` on gcc 13.

**Solution:** Added the required include directive.

### 3. Duplicate Using Declarations
**Problem:** Duplicate `using QComboBox::activated;` declaration in `zcolorcombobox.h` causing compilation errors.

**Solution:** Commented out the duplicate declarations.

## Changes Made

- `groups.cpp`: Added explicit template instantiations for `GroupCategory<KanjiGroup>` and `GroupCategory<WordGroup>` specializations
- `checked_cast.h`: Added `#include <cstdint>` header
- `zcolorcombobox.h`: Fixed duplicate using declarations
- `.gitignore`: Updated to exclude Qt build artifacts and generated files


## Platform

Tested on: Ubuntu 22.04 with gcc 13 and Qt 5